### PR TITLE
fix: update equatable_annotations dependency to version ^1.0.0

### DIFF
--- a/equatable_gen/pubspec.yaml
+++ b/equatable_gen/pubspec.yaml
@@ -19,7 +19,7 @@ environment:
 
 dependencies:
   analyzer: ">=5.0.0 <8.0.0"
-  equatable_annotations: ">=0.1.0 <1.0.0"
+  equatable_annotations: ^1.0.0
   build: ^2.4.1
   code_builder: ^4.8.0
   change_case: ^2.2.0


### PR DESCRIPTION
This pull request updates the dependency version for `equatable_annotations` in the `equatable_gen/pubspec.yaml` file to ensure compatibility with the latest features and improvements.

Dependency updates:

* Updated the `equatable_annotations` dependency version from `">=0.1.0 <1.0.0"` to `^1.0.0` in `equatable_gen/pubspec.yaml` to align with the latest stable release.

---

Fixes #1 