### PR TITLE
chore: broaden version constraints for build and source_gen dependencies

### DIFF
--- a/e2e_tests/lib/gen/extends/private_class.dart
+++ b/e2e_tests/lib/gen/extends/private_class.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unused_element_parameter
+
 import 'package:equatable/equatable.dart';
 
 part 'private_class.g.dart';

--- a/e2e_tests/lib/gen/mixin/private_class.dart
+++ b/e2e_tests/lib/gen/mixin/private_class.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unused_element_parameter
+
 import 'package:equatable/equatable.dart';
 
 part 'private_class.g.dart';

--- a/equatable_annotations/example/main.dart
+++ b/equatable_annotations/example/main.dart
@@ -5,11 +5,7 @@ part 'main.g.dart';
 
 @generateProps
 class ExampleClass extends Equatable {
-  const ExampleClass({
-    required this.value,
-    this.ignored,
-    this.optional,
-  });
+  const ExampleClass({required this.value, this.ignored, this.optional});
 
   final String? optional;
   final String value;

--- a/equatable_annotations/pubspec.yaml
+++ b/equatable_annotations/pubspec.yaml
@@ -15,12 +15,12 @@ topics:
   - generator
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.7.0
 
 dependencies:
   meta: ^1.9.1
 
 dev_dependencies:
   equatable: ^2.0.7
-  lints: ^6.0.0
+  lints: ">=5.1.1 <7.0.0"
   test: ^1.26.3

--- a/equatable_gen/example/main.dart
+++ b/equatable_gen/example/main.dart
@@ -5,11 +5,7 @@ part 'main.g.dart';
 
 @generateProps
 class Example1Class extends Equatable {
-  Example1Class({
-    required this.value,
-    this.ignored,
-    this.optional,
-  });
+  Example1Class({required this.value, this.ignored, this.optional});
 
   final String value;
   final String? optional;
@@ -23,11 +19,7 @@ class Example1Class extends Equatable {
 
 @generateProps
 class Example2Class with EquatableMixin {
-  const Example2Class({
-    required this.value,
-    this.ignored,
-    this.optional,
-  });
+  const Example2Class({required this.value, this.ignored, this.optional});
 
   final String value;
   final String? optional;

--- a/equatable_gen/lib/equatable_gen.dart
+++ b/equatable_gen/lib/equatable_gen.dart
@@ -9,10 +9,5 @@ import 'package:source_gen/source_gen.dart';
 Builder equatableGenerator(BuilderOptions options) {
   final settings = Settings.fromJson(options.config);
 
-  return SharedPartBuilder(
-    [
-      EquatableGenerator(settings),
-    ],
-    'equatable_gen',
-  );
+  return SharedPartBuilder([EquatableGenerator(settings)], 'equatable_gen');
 }

--- a/equatable_gen/lib/gen/settings.g.dart
+++ b/equatable_gen/lib/gen/settings.g.dart
@@ -7,21 +7,19 @@ part of 'settings.dart';
 // **************************************************************************
 
 Settings _$SettingsFromJson(Map json) => Settings.defaults(
-      includeGetters: json['include_getters'] as bool? ?? false,
-      autoInclude: json['auto_include'] as bool? ?? false,
-      exclude: (json['exclude'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          const [],
-      include: (json['include'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          const [],
-    );
+  includeGetters: json['include_getters'] as bool? ?? false,
+  autoInclude: json['auto_include'] as bool? ?? false,
+  exclude:
+      (json['exclude'] as List<dynamic>?)?.map((e) => e as String).toList() ??
+      const [],
+  include:
+      (json['include'] as List<dynamic>?)?.map((e) => e as String).toList() ??
+      const [],
+);
 
 Map<String, dynamic> _$SettingsToJson(Settings instance) => <String, dynamic>{
-      'auto_include': instance.autoInclude,
-      'exclude': instance.exclude,
-      'include': instance.include,
-      'include_getters': instance.includeGetters,
-    };
+  'auto_include': instance.autoInclude,
+  'exclude': instance.exclude,
+  'include': instance.include,
+  'include_getters': instance.includeGetters,
+};

--- a/equatable_gen/lib/src/element_extensions.dart
+++ b/equatable_gen/lib/src/element_extensions.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:equatable_gen/src/checkers/checkers.dart';
@@ -14,11 +16,7 @@ extension ClassElementX on ClassElement2 {
   bool get equatableIsSuper => equatableChecker.isSuperOf(this);
 
   bool get superHasProps {
-    final ignore = {
-      'Object',
-      'Equatable',
-      'EquatableMixin',
-    };
+    final ignore = {'Object', 'Equatable', 'EquatableMixin'};
 
     for (final InterfaceType superType in allSupertypes) {
       final element = superType.element3;

--- a/equatable_gen/lib/src/enums/equatable_type.dart
+++ b/equatable_gen/lib/src/enums/equatable_type.dart
@@ -1,9 +1,5 @@
 /// The type of [Equatable] inheritance.
-enum EquatableType {
-  class_,
-  mixin,
-  none,
-}
+enum EquatableType { class_, mixin, none }
 
 /// The extension for [EquatableType] to check annotated elements'
 /// equatable_annotations types.

--- a/equatable_gen/lib/src/generator.dart
+++ b/equatable_gen/lib/src/generator.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 library;
 
 import 'dart:async' show FutureOr;

--- a/equatable_gen/lib/src/models/equatable_element.dart
+++ b/equatable_gen/lib/src/models/equatable_element.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:change_case/change_case.dart';
 import 'package:equatable_gen/src/element_extensions.dart';
@@ -11,7 +13,7 @@ class EquatableElement {
     required bool hasPropsField,
     required this.isAutoInclude,
   }) : shouldCreateExtension =
-            (isAutoInclude || hasAnnotation) && hasPropsField;
+           (isAutoInclude || hasAnnotation) && hasPropsField;
 
   final ClassElement2 element;
   final bool hasAnnotation;

--- a/equatable_gen/lib/src/visitors/class_visitor.dart
+++ b/equatable_gen/lib/src/visitors/class_visitor.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/visitor2.dart';
 import 'package:equatable_gen/gen/settings.dart';
@@ -56,8 +58,11 @@ class ClassVisitor extends RecursiveElementVisitor2<void> {
         break;
       }
 
-      props.addAll(clazz.fields2
-          .where((e) => _includeField(e, settings, isSuper: isSuper)));
+      props.addAll(
+        clazz.fields2.where(
+          (e) => _includeField(e, settings, isSuper: isSuper),
+        ),
+      );
       clazz = clazz.supertype?.element3 as ClassElement2?;
       isSuper = true;
     } while (clazz != null);

--- a/equatable_gen/lib/src/writers/write_extension.dart
+++ b/equatable_gen/lib/src/writers/write_extension.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: deprecated_member_use
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:change_case/change_case.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:equatable_gen/src/models/equatable_element.dart';

--- a/equatable_gen/lib/src/writers/write_extension.dart
+++ b/equatable_gen/lib/src/writers/write_extension.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:change_case/change_case.dart';
 import 'package:code_builder/code_builder.dart';
@@ -12,20 +14,23 @@ Extension writeExtension(EquatableElement element) {
       element.name.replaceAll(RegExp('^_+'), '').toPascalCase();
 
   return Extension(
-    (b) => b
-      ..name = '_\$${sanitizedName}EquatableAnnotations'
-      ..on = refer(element.name)
-      ..methods.add(
-        Method(
-          (b) => b
-            ..returns = refer('List<Object?>')
-            ..type = MethodType.getter
-            ..name = '_\$props'
-            ..body = literalList([
-              for (final FieldElement2 f in element.props)
-                if (f.name3 case final String name?) refer(name),
-            ]).code,
-        ),
-      ),
+    (b) =>
+        b
+          ..name = '_\$${sanitizedName}EquatableAnnotations'
+          ..on = refer(element.name)
+          ..methods.add(
+            Method(
+              (b) =>
+                  b
+                    ..returns = refer('List<Object?>')
+                    ..type = MethodType.getter
+                    ..name = '_\$props'
+                    ..body =
+                        literalList([
+                          for (final FieldElement2 f in element.props)
+                            if (f.name3 case final String name?) refer(name),
+                        ]).code,
+            ),
+          ),
   );
 }

--- a/equatable_gen/lib/src/writers/write_file.dart
+++ b/equatable_gen/lib/src/writers/write_file.dart
@@ -5,7 +5,5 @@ import 'package:equatable_gen/src/writers/write_extension.dart';
 List<Spec> writeFile(List<EquatableElement> equatables) {
   final extensions = equatables.map(writeExtension);
 
-  return [
-    ...extensions,
-  ];
+  return [...extensions];
 }

--- a/equatable_gen/pubspec.yaml
+++ b/equatable_gen/pubspec.yaml
@@ -15,18 +15,18 @@ topics:
   - generator
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.7.0
 
 dependencies:
   analyzer: ">=7.4.0 <9.0.0"
   equatable_annotations: ^1.1.0
-  build: ^3.1.0
+  build: ">=3.1.0 <5.0.0"
   code_builder: ^4.10.1
   change_case: ^2.2.0
   dart_style: ^3.1.1
   equatable: ^2.0.7
   meta: ">=1.0.0 <2.0.0"
-  source_gen: ^3.1.0
+  source_gen: ">=3.1.0 <5.0.0"
   path: ">=1.0.0 <2.0.0"
   source_span: ^1.10.1
   yaml: ^3.1.3
@@ -34,6 +34,6 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.7.1
   build_test: ^3.3.3
-  generator_test: ^0.5.0
-  lints: ^6.0.0
+  generator_test: ">=0.5.0 <1.0.0"
+  lints: ">=5.1.1 <7.0.0"
   test: ^1.26.3

--- a/equatable_gen/test/generator_test.dart
+++ b/equatable_gen/test/generator_test.dart
@@ -13,9 +13,7 @@ void main() {
         [input],
         [output],
         equatableGenerator,
-        options: Settings.defaults(
-          autoInclude: true,
-        ).toJson(),
+        options: Settings.defaults(autoInclude: true).toJson(),
       );
 
       final rw = TestReaderWriter(rootPackage: 'a');


### PR DESCRIPTION
This pull request introduces several code style and dependency updates across the `equatable_gen` and `equatable_annotations` packages. The main focus is on code formatting improvements for readability and maintainability, updating SDK and dependency constraints, and adding ignore directives for deprecated or unused elements. Functional logic remains unchanged.

**Code formatting and style improvements:**

* Reformatted constructors in `ExampleClass`, `Example1Class`, and `Example2Class` to use a single line, improving readability (`equatable_annotations/example/main.dart`, `equatable_gen/example/main.dart`). [[1]](diffhunk://#diff-b7a2a0d7033b4390af4ed11b48ec17b9c96197678301c45cb8de40bc73175a26L8-R8) [[2]](diffhunk://#diff-f5a805851fcd815a38df205380d56777811554d386c00bdf6c9a337cc7c4ea3cL8-R8) [[3]](diffhunk://#diff-f5a805851fcd815a38df205380d56777811554d386c00bdf6c9a337cc7c4ea3cL26-R22)
* Simplified collection initializations and method calls for better clarity and consistency in several files, including `element_extensions.dart`, `enums/equatable_type.dart`, `generator.dart`, `models/equatable_element.dart`, `visitors/class_visitor.dart`, `writers/write_extension.dart`, `writers/write_file.dart`, and `generator_test.dart`. [[1]](diffhunk://#diff-9d306a473d0d29948eee40af18f327fee4c58e2d8af855078eaafdfdc95361acL17-R19) [[2]](diffhunk://#diff-8eed92bf8718b2f7beefa624e162a03aa381379c1b9eb414c40356d9f70afa51L2-R2) [[3]](diffhunk://#diff-74c4441ad6f16832aae8ddc30e0a73ad5b3183fe56ff0ae2ddd430865a21c359L12-R12) [[4]](diffhunk://#diff-4d60bd42d75e4f2062623578d10d0ca5957a089a6f95ae1a34214e6bd2f4b770R1-R2) [[5]](diffhunk://#diff-b844ac199a0d970146df2c0fca4dd6f53fde908a326e275f6e4c2943b11fee0aL59-R65) [[6]](diffhunk://#diff-40b6d5a1c78fb5822d0681ae5e48dbf989d1c05a9fd1c4eec537f8426683a594L15-R29) [[7]](diffhunk://#diff-3e60ec92038ba2a7108040f40bbd83a8dd61c4b9b5a8ab0c255897856b88460cL8-R8) [[8]](diffhunk://#diff-64583e0740ede1e6b6aab03ddadcad638ca2d29e0355ab144521e76d72ebd44bL16-R16) [[9]](diffhunk://#diff-732b212efc8677a2858ed71b63fac383274d42002783cd02ab18ade6cced36d3L12-R16)

**Dependency and environment updates:**

* Updated Dart SDK and dependency constraints in `pubspec.yaml` files for both `equatable_annotations` and `equatable_gen`, ensuring compatibility with newer versions and a wider range of supported versions. [[1]](diffhunk://#diff-07f0f8ccb7dcb5ad688eea0a247392dccf06fd4e2540fbac9c1ab79ebc3437a1L18-R25) [[2]](diffhunk://#diff-4d42464d6399c40651ed1f4e782d5c2f85275c153d98481f6363bb616577c092L18-R38)

**Codebase maintenance:**

* Added `// ignore_for_file` directives to suppress warnings for deprecated members and unused parameters in generated and source files, improving signal-to-noise ratio during analysis and testing (`private_class.dart`, `element_extensions.dart`, `generator.dart`, `models/equatable_element.dart`, `class_visitor.dart`, `write_extension.dart`). [[1]](diffhunk://#diff-902b052dd50ca84c5847a0887876d474c39db57d2832fb80681762b6b6027315R1-R2) [[2]](diffhunk://#diff-1a1a48ffa907e9b2165e2bf88ee26e4d2c229d760dfd71741fb620c93032fb8dR1-R2) [[3]](diffhunk://#diff-9d306a473d0d29948eee40af18f327fee4c58e2d8af855078eaafdfdc95361acR1-R2) [[4]](diffhunk://#diff-a3b5c4f4ec0d13d2acec4b5a444a8eeefeec6a1b722308e72741c6a4b39e2ef1R1-R2) [[5]](diffhunk://#diff-4d60bd42d75e4f2062623578d10d0ca5957a089a6f95ae1a34214e6bd2f4b770R1-R2) [[6]](diffhunk://#diff-b844ac199a0d970146df2c0fca4dd6f53fde908a326e275f6e4c2943b11fee0aR1-R2) [[7]](diffhunk://#diff-40b6d5a1c78fb5822d0681ae5e48dbf989d1c05a9fd1c4eec537f8426683a594R1-R2)

These changes are primarily non-functional and focus on code health, style consistency, and future-proofing the packages.